### PR TITLE
Fix Rust test library path in the Cabal file

### DIFF
--- a/curryrs.cabal
+++ b/curryrs.cabal
@@ -31,7 +31,7 @@ test-suite curryrs-test
                      , tasty-hunit >= 0.9.2
   -- We only have to do this because ghc-pkg doesn't work with relative paths for
   -- extra-lib-dirs.
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Ltarget/release -lrtest -lpthread
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Lrtest/target/release -lrtest -lpthread
   default-language:    Haskell2010
 
 benchmark curryrs-bench
@@ -42,7 +42,7 @@ benchmark curryrs-bench
                      , curryrs
   -- We only have to do this because ghc-pkg doesn't work with relative paths for
   -- extra-lib-dirs.
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Ltarget/release -lrtest -lpthread
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Lrtest/target/release -lrtest -lpthread
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
I think this is what you meant, and it makes `make test` work.