### PR TITLE
Use fixed width integer types for FFI

### DIFF
--- a/haskell-tests/Test.hs
+++ b/haskell-tests/Test.hs
@@ -5,7 +5,7 @@ import Convert
 import Test.Tasty
 import Test.Tasty.HUnit
 
-foreign import ccall "double_input" doubleInput :: I32 -> I32
+foreign import ccall "double_input" doubleInput :: Int32 -> Int32
 foreign import ccall "get_true" getTrue :: Boolean
 foreign import ccall "get_false" getFalse :: Boolean
 

--- a/haskell-tests/Test.hs
+++ b/haskell-tests/Test.hs
@@ -5,7 +5,7 @@ import Convert
 import Test.Tasty
 import Test.Tasty.HUnit
 
-foreign import ccall "double_input" doubleInput :: Int32 -> Int32
+foreign import ccall "double_input" doubleInput :: I32 -> I32
 foreign import ccall "get_true" getTrue :: Boolean
 foreign import ccall "get_false" getFalse :: Boolean
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -7,19 +7,29 @@ module Types (
   , module Foreign.C.String
   , Chr
   , Str
-  , U8
-  , U16
-  , U32
-  , U64
-  , I8
-  , I16
-  , I32
-  , I64
-  , F32
-  , F64
+  , Word8
+  -- | Used to represent 8 bit unsigned numbers in both languages
+  , Word16
+  -- | Used to represent 16 bit unsigned numbers in both languages
+  , Word32
+  -- | Used to represent 32 bit unsigned numbers in both languages
+  , Word64
+  -- | Used to represent 64 bit unsigned numbers in both languages
+  , Int8
+  -- | Used to represent 8 bit signed numbers in both languages
+  , Int16
+  -- | Used to represent 16 bit signed numbers in both languages
+  , Int32
+  -- | Used to represent 32 bit signed numbers in both languages
+  , Int64
+  -- | Used to represent 64 bit signed numbers in both languages
+  , Float32
+  , Float64
   , Boolean
   ) where
 
+import Data.Int
+import Data.Word
 import Foreign.C.Types
 import Foreign.C.String
 
@@ -35,45 +45,13 @@ type Chr = CChar
 type Str = CString
 
 -- |
--- Used to represent 8 bit unsigned numbers in both languages
-type U8  = CUChar
-
--- |
--- Used to represent 16 bit unsigned numbers in both languages
-type U16 = CUShort
-
--- |
--- Used to represent 32 bit unsigned numbers in both languages
-type U32 = CUInt
-
--- |
--- Used to represent 64 bit unsigned numbers in both languages
-type U64 = CULong
-
--- |
--- Used to represent 8 bit signed numbers in both languages
-type I8  = CSChar
-
--- |
--- Used to represent 16 bit signed numbers in both languages
-type I16 = CShort
-
--- |
--- Used to represent 32 bit signed numbers in both languages
-type I32 = CInt
-
--- |
--- Used to represent 64 bit signed numbers in both languages
-type I64 = CLong
-
--- |
 -- Used to represent 32 bit floating point numbers in both languages
-type F32 = CFloat
+type Float32 = CFloat
 
 -- |
 -- Used to represent 64 bit floating point numbers in both languages
-type F64 = CDouble
+type Float64 = CDouble
 
 -- |
 -- Used to represent Booleans in both languages
-type Boolean = CUChar
+type Boolean = Word8

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -7,24 +7,16 @@ module Types (
   , module Foreign.C.String
   , Chr
   , Str
-  , Word8
-  -- | Used to represent 8 bit unsigned numbers in both languages
-  , Word16
-  -- | Used to represent 16 bit unsigned numbers in both languages
-  , Word32
-  -- | Used to represent 32 bit unsigned numbers in both languages
-  , Word64
-  -- | Used to represent 64 bit unsigned numbers in both languages
-  , Int8
-  -- | Used to represent 8 bit signed numbers in both languages
-  , Int16
-  -- | Used to represent 16 bit signed numbers in both languages
-  , Int32
-  -- | Used to represent 32 bit signed numbers in both languages
-  , Int64
-  -- | Used to represent 64 bit signed numbers in both languages
-  , Float32
-  , Float64
+  , U8
+  , U16
+  , U32
+  , U64
+  , I8
+  , I16
+  , I32
+  , I64
+  , F32
+  , F64
   , Boolean
   ) where
 
@@ -45,12 +37,44 @@ type Chr = CChar
 type Str = CString
 
 -- |
+-- Used to represent 8 bit unsigned numbers in both languages
+type U8  = Word8
+
+-- |
+-- Used to represent 16 bit unsigned numbers in both languages
+type U16 = Word16
+
+-- |
+-- Used to represent 32 bit unsigned numbers in both languages
+type U32 = Word32
+
+-- |
+-- Used to represent 64 bit unsigned numbers in both languages
+type U64 = Word64
+
+-- |
+-- Used to represent 8 bit signed numbers in both languages
+type I8  = Int8
+
+-- |
+-- Used to represent 16 bit signed numbers in both languages
+type I16 = Int16
+
+-- |
+-- Used to represent 32 bit signed numbers in both languages
+type I32 = Int32
+
+-- |
+-- Used to represent 64 bit signed numbers in both languages
+type I64 = Int64
+
+-- |
 -- Used to represent 32 bit floating point numbers in both languages
-type Float32 = CFloat
+type F32 = CFloat
 
 -- |
 -- Used to represent 64 bit floating point numbers in both languages
-type Float64 = CDouble
+type F64 = CDouble
 
 -- |
 -- Used to represent Booleans in both languages

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,20 +2,12 @@
 
 pub use std::os::raw::{
 	c_char,
-	c_uchar,
-	c_ushort,
-	c_uint,
-	c_ulong,
-	c_schar,
-	c_short,
-	c_int,
-	c_long,
 	c_float,
 	c_double
 };
 
-/// FFI Version of char
-pub type Boolean = c_uchar;
+/// FFI Version of bool
+pub type Boolean = u8;
 
 /// FFI Version of char
 pub type Chr = c_char;
@@ -24,28 +16,28 @@ pub type Chr = c_char;
 pub type Str = *const c_char;
 
 /// FFI version of u8
-pub type U8  = c_uchar;
+pub type U8  = u8;
 
 /// FFI version of u16
-pub type U16 = c_ushort;
+pub type U16 = u16;
 
 /// FFI version of u32
-pub type U32 = c_uint;
+pub type U32 = u32;
 
 /// FFI version of u64
-pub type U64 = c_ulong;
+pub type U64 = u64;
 
 /// FFI version of i8
-pub type I8  = c_schar;
+pub type I8  = i8;
 
 /// FFI version of i16
-pub type I16 = c_short;
+pub type I16 = i16;
 
 /// FFI version of i32
-pub type I32 = c_int;
+pub type I32 = i32;
 
 /// FFI version of i64
-pub type I64 = c_long;
+pub type I64 = i64;
 
 /// FFI version of f32
 pub type F32 = c_float;


### PR DESCRIPTION
The built-in C integer types are only guaranteed minimum sizes, not exact sizes. `int` and `long` as used here also may be shorter than expected (down to 16 and 32 bits).

Since the types being exposed are fixed width, and both Haskell[1] and Rust[2] support using fixed width integers in foreign calls, just use those directly.

The Haskell fixed width integer types are now re-exported from Data.Int and Data.Word for consistency with other packages.

Haskell also translates it's `Bool` type as a C `int`, though using that directly would remove the ability to check that the value is exactly 0 or 1 on the Haskell side. The floating point types could also probably just be `= Float/Double` and `= f32/f64` as C has weaker requirements on its floating point types than Rust does, and every Haskell implementation that I know of uses 32 and 64 bit sizes for `Float` and `Double`.

[1]: Haskell 2010 Report, [8.4.2 Foreign Types](https://www.haskell.org/onlinereport/haskell2010/haskellch8.html#x15-1560008.4.2) and and [8.7 The External C Interface](https://www.haskell.org/onlinereport/haskell2010/haskellch8.html#x15-1700008.7).
[2]: [The Rust Programming Language, FFI](https://doc.rust-lang.org/book/ffi.html#callbacks-from-c-code-to-rust-functions)