### PR TITLE
Call hs_init from Rust directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ test: build
 	@  (command -v stack 1,2>/dev/null && cd htest && stack build) \
 	|| (command -v cabal 1,2>/dev/null && cd htest && cabal build) \
 	|| (echo "ERROR: cabal or stack not found" && exit 1)
-	@  (cd htest && gcc -shared -o libchtest.so chtest.c libhtest.so -fPIC -Wno-implicit) \
-	|| (echo "ERROR: gcc not found" && exit 1)
 	@cargo test
 	@  (command -v stack 1,2>/dev/null && stack test) \
 	|| (command -v cabal 1,2>/dev/null && cabal test) \

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,38 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use std::{env, str};
+
+fn command_output(cmd: &mut Command) -> String {
+	str::from_utf8(&cmd.output().unwrap().stdout)
+		.unwrap()
+		.trim_right()
+		.to_string()
+}
+
+fn command_ok(cmd: &mut Command) -> bool {
+	cmd.status().ok().map_or(false, |s| s.success())
+}
+
+fn ghc(builder: &str, arg: &str) -> String {
+	command_output(Command::new(builder).args(&["exec", "--", "ghc", arg]))
+}
+
 fn main() {
+	let builder = if command_ok(Command::new("stack").arg("--version")) {
+		"stack"
+	} else {
+		"cabal"
+	};
+	let ghc_version = ghc(builder, "--numeric-version");
+	let ghc_libdir = ghc(builder, "--print-libdir");
 	println!("cargo:rustc-link-search=native=htest");
-	//println!("cargo:rustc-link-lib=static=htest");
+	println!("cargo:rustc-link-search=native={}/rts", ghc_libdir);
+
+	let out_dir = env::var("OUT_DIR").unwrap();
+	let dest_path = Path::new(&out_dir).join("hs_rts.rs");
+	let mut f = File::create(&dest_path).unwrap();
+	let ghc_rts_rs = format!("#[link(name = \"HSrts-ghc{}\")]\nextern {{}}\n", ghc_version);
+	f.write_all(ghc_rts_rs.as_bytes()).unwrap();
 }

--- a/htest/chtest.c
+++ b/htest/chtest.c
@@ -1,9 +1,0 @@
-int tripleNum(int x) {
-  static char *argv[] = { "libchtest.so", 0 }, **argv_ = argv;
-  static int argc = 1;
-
-  hs_init(&argc, &argv_);
-  int y = triple(x);
-  hs_exit();
-  return y;
-}

--- a/htest/hsbracket.c
+++ b/htest/hsbracket.c
@@ -1,1 +1,0 @@
-#include <HsFFI.h>

--- a/htest/htest.cabal
+++ b/htest/htest.cabal
@@ -15,8 +15,8 @@ library
   hs-source-dirs:      src
                      , ../src
   exposed-modules:     Lib
+  other-modules:       Types
   other-extensions:    ForeignFunctionInterface
-  ghc-options:         -dynamic -fPIC -shared -lHSrts-ghc8.0.1 -o libhtest.so
+  ghc-options:         -dynamic -fPIC -shared -o libhtest.so
   build-depends:       base >= 4.7 && < 5
-  c-sources:           hsbracket.c
   default-language:    Haskell2010

--- a/tests/haskell_import.rs
+++ b/tests/haskell_import.rs
@@ -1,13 +1,34 @@
 extern crate curryrs;
 use curryrs::types::*;
+use std::os::raw::c_int;
+use std::ptr;
+
+#[link(name = "htest", kind = "dylib")]
+extern {
+	pub fn triple(x: I32) -> I32;
+}
+
+include!(concat!(env!("OUT_DIR"), "/hs_rts.rs"));
+
+extern {
+	pub fn hs_init(argc: *mut c_int, argv: *mut *mut *mut c_char);
+	pub fn hs_exit();
+}
+
+fn triple_num(x: I32) -> I32 {
+	let mut argv0 = *b"triple_test\0";
+	let mut argv = [argv0.as_mut_ptr() as *mut c_char, ptr::null_mut()];
+	let mut argc = (argv.len() - 1) as c_int;
+
+	unsafe {
+		hs_init(&mut argc, &mut argv.as_mut_ptr());
+		let y = triple(x);
+		hs_exit();
+		y
+	}
+}
 
 #[test]
 fn triple_test() {
-	#[link(name = "chtest", kind="dylib")]
-	#[link(name = "htest", kind="dylib")]
-	extern {
-		pub fn tripleNum(x:I32) -> I32;
-	}
-
-	assert_eq!(900, unsafe{tripleNum(300)});
+	assert_eq!(900, triple_num(300));
 }


### PR DESCRIPTION
Some remaining issues:

- `cargo test` will run correctly, as it [sets `(DY)?LD_LIBRARY_PATH`][1] before running the test binary, but building deployable executables will probably require adding rpaths.
- If more tests are added, some global mechanism of initializing the Haskell runtime will be needed as [the GHC runtime apparently doesn't support re-initializing after shutdown][2].
- The arguments passed to `hs_init` should be fetched from [`std::env::ArgsOs`][3].

Nice work figuring this out, by the way. I've always had to resort to a Haskell -> Other Language -> Haskell inversion of control to avoid building the executable without GHC.

[1]: https://github.com/rust-lang/cargo/blob/5f2cc15de7cf51a362fb8320d8e81e6da67f1aab/src/cargo/ops/cargo_rustc/compilation.rs#L133
[2]: https://downloads.haskell.org/~ghc/7.0.3/docs/html/users_guide/ffi-ghc.html#hs-exit
[3]: https://doc.rust-lang.org/stable/std/env/struct.ArgsOs.html