### PR TITLE
Add Haskell Runtime interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ indent_style = tab
 
 [*.rs]
 indent_style = tab
+indent_size = 4
 
 [*.hs]
 indent_style = space

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,11 @@ exclude = [
 members = ["rtest"]
 
 [dependencies]
+
+[features]
+# Features available for chooising alternative
+# Runtime libraries for Haskell. By default it
+# is the non-threaded non-debug version
+threaded = []
+threaded_l = []
+threaded_debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = ["rtest"]
 [dependencies]
 
 [features]
-# Features available for chooising alternative
+# Features available for choosing alternative
 # Runtime libraries for Haskell. By default it
 # is the non-threaded non-debug version
 threaded = []

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ fn main() {
   // or calls to Haskell code will fail.
   start("Haskell Functions".to_string());
 
-  println!("2^4 is: {}, unsafe{fourth(2)});
-  println!("2^5 is: {}, unsafe{fifth(2)});
-  println!("2^6 is: {}, unsafe{sixth(2)});
+  println!("2^4 is: {}", unsafe{fourth(2)});
+  println!("2^5 is: {}", unsafe{fifth(2)});
+  println!("2^6 is: {}", unsafe{sixth(2)});
 
   // You need to make sure the runtime is stopped
   // otherwise you'll have undefined behavior

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ In your Rust project in Cargo.toml:
 
 ```toml
 [dependencies]
-curryrs = "^0.1.0"
+curryrs = "^0.2.0"
 ```
 
 In your Haskell project in it's cabal file:
 
 ```cabal
-build-depends: curryrs >= 0.1.0 < 0.2.0
+build-depends: curryrs >= 0.2.0 < 0.3.0
 ```
 
 ## How to use Curryrs
@@ -32,6 +32,7 @@ conversion module only affects the Boolean type, however work in the
 future of this module will likely include structs and other more complicated
 data structures.
 
+### Rust in Haskell
 If you want to create functions that export to Haskell from Rust do the
 following:
 
@@ -86,8 +87,108 @@ ninthPower :: I64 -> I64
 ninthPower x = cube $ cube x
 ```
 
-Using Haskell in Rust is a little more complicated as I've found out working on this library.
-I have a more detailed post on how to get it working [here](http://mgattozzi.github.io/2016/10/15/rust-haskell.html) using curryrs that you can reference.
+### Haskell in Rust
+To run your Haskell code in Rust do the following steps:
+
+First write and export the code you want for Haskell and use
+the Curryrs.Types module to have FFI compatible types.
+
+```haskell
+import Curryrs.Types
+
+foreign export ccall fourth :: I64 -> I64
+foreign export ccall fifth :: I64 -> I64
+foreign export ccall sixth :: I64 -> I64
+
+fourth :: I64 -> I64
+fourth x = x * x * x * x
+
+fifth :: I64 -> I64
+fithh x = x * x * x * x * x
+
+sixth :: I64 -> I64
+sixth x = x * x * x * x * x * x
+```
+
+In your cabal file add the following lines:
+
+```cabal
+other-extensions: ForeignFunctionInterface
+-- It should end with .so if you're on linux, .dylib for Mac, and
+-- .dll for Windows
+ghc-options: -dynamic -fPIC -shared -o lib{your_library_name_here}.so
+```
+
+Now in your Cargo.toml file add the following under package:
+
+```toml
+build = "build.rs"
+```
+
+Then in your `build.rs` file:
+
+```rust
+fn main() {
+  println!("cargo:rustc-link-search=native={path_to_your_haskell_library_directory}");
+  println!("cargo:rustc-link-lib=native={library_name_w/o_lib_and_extension}");
+}
+```
+
+This links your Haskell library in at compilation. Now for the actual
+code itself:
+
+```rust
+extern crate curryrs;
+use curryrs::hsrt::{start,stop};
+use curryrs::types::I64;
+
+extern {
+  pub fn fourth(x: I64) -> I64;
+  pub fn fifth(x: I64) -> I64;
+  pub fn sixth(x: I64) -> I64;
+}
+
+fn main() {
+  // Input is whatever you want to pass to argv whenever
+  // you start the Haskell Runtime. You need to start it
+  // or calls to Haskell code will fail.
+  start("Haskell Functions".to_string());
+
+  println!("2^4 is: {}, unsafe{fourth(2)});
+  println!("2^5 is: {}, unsafe{fifth(2)});
+  println!("2^6 is: {}, unsafe{sixth(2)});
+
+  // You need to make sure the runtime is stopped
+  // otherwise you'll have undefined behavior
+  // and wasted resources.
+  stop();
+```
+
+This makes it easy to do without needing to muck around with linking the
+right libraries and you're easily able to call the runtime you want.
+
+The library also allows you to choose which version of the Haskell
+Runtime you want to use. By default it uses the non-threaded version.
+You can choose which one you want with a feature flag in `Cargo.toml`
+
+```toml
+[dependencies]
+# If you need the threaded runtime put this:
+curryrs = { version = "^0.2.0", features = "threaded" }
+
+# If you need the threaded runtime w/ logging put this:
+curryrs = { version = "^0.2.0", features = "threaded_l" }
+
+# If you need the threaded runtime w/ debug output put this:
+curryrs = { version = "^0.2.0", features = "threaded_debug" }
+```
+
+## Bug Reports
+If you encounter errors of any sort please take a look in the issue
+tracker first. If your error is already there or has been closed before
+take a look at how it was solved or contribute to the open bug by
+explaining what has happened while using the library. Duplicates will be
+marked and closed.
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ In your cabal file add the following lines:
 
 ```cabal
 other-extensions: ForeignFunctionInterface
+
 -- It should end with .so if you're on linux, .dylib for Mac, and
 -- .dll for Windows
 ghc-options: -dynamic -fPIC -shared -o lib{your_library_name_here}.so
@@ -162,6 +163,7 @@ fn main() {
   // otherwise you'll have undefined behavior
   // and wasted resources.
   stop();
+}
 ```
 
 This makes it easy to do without needing to muck around with linking the

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In your cabal file add the following lines:
 ```cabal
 other-extensions: ForeignFunctionInterface
 
--- It should end with .so if you're on linux, .dylib for Mac, and
+-- It should end with .so if you're on Linux, .dylib for Mac, and
 -- .dll for Windows
 ghc-options: -dynamic -fPIC -shared -o lib{your_library_name_here}.so
 ```

--- a/curryrs.cabal
+++ b/curryrs.cabal
@@ -14,8 +14,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Types
-                     , Convert
+  exposed-modules:     Curryrs.Types
+                     , Curryrs.Convert
   build-depends:       base >= 4.7 && < 5
                      , mtl  >= 2.2 && < 2.3
   default-language:    Haskell2010

--- a/haskell-tests/Test.hs
+++ b/haskell-tests/Test.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Types
-import Convert
+import Curryrs.Types
+import Curryrs.Convert
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/htest/htest.cabal
+++ b/htest/htest.cabal
@@ -15,7 +15,7 @@ library
   hs-source-dirs:      src
                      , ../src
   exposed-modules:     Lib
-  other-modules:       Types
+  other-modules:       Curryrs.Types
   other-extensions:    ForeignFunctionInterface
   ghc-options:         -dynamic -fPIC -shared -o libhtest.so
   build-depends:       base >= 4.7 && < 5

--- a/htest/src/Lib.hs
+++ b/htest/src/Lib.hs
@@ -2,7 +2,7 @@
 
 module Lib where
 
-import Types
+import Curryrs.Types
 
 triple :: I64 -> I64
 triple x = 3 * x

--- a/src/Curryrs/Convert.hs
+++ b/src/Curryrs/Convert.hs
@@ -2,12 +2,12 @@
 -- The Convert module contains various functions used for converting
 -- values to or from their FFI form. It also contains Error types in
 -- case conversions to not go as planned.
-module Convert (
+module Curryrs.Convert (
     fromBoolean
   , ConversionError
   ) where
 
-import Types (Boolean)
+import Curryrs.Types (Boolean)
 
 -- |
 -- This method tries to to turn a number returned

--- a/src/Curryrs/Types.hs
+++ b/src/Curryrs/Types.hs
@@ -2,7 +2,7 @@
 -- Definitions of each FFI type that can be used in Rust. These are
 -- standardized accross the Rust and Haskell Curryrs library for easy
 -- translation of function headers between the two.
-module Types (
+module Curryrs.Types (
     module Foreign.C.Types
   , module Foreign.C.String
   , Chr

--- a/src/hsrt.rs
+++ b/src/hsrt.rs
@@ -1,0 +1,37 @@
+//! Functions related to the Haskell Runtime wrapped up in a safe interface for
+//! the user.
+//!
+
+use std::os::raw::{c_char, c_int};
+use std::ptr;
+
+extern {
+	pub fn hs_init(argc: *mut c_int, argv: *mut *mut *mut c_char);
+	pub fn hs_exit();
+}
+
+/// Initialize the Haskell runtime
+///
+/// func is what you pass to the argv part of the C Call to hs_init
+///
+/// If you call `hs_start()` you absolutely must call `hs_stop()` forgetting to
+/// do so will cause undefined behavior and the runtime will run without
+/// stopping. This could cause memory leaks or a whole bunch of other
+/// errors that can't be checked.
+pub fn hs_start(mut func: String) {
+	func.push('\0');
+	let argv0 = func.as_ptr();
+	let mut argv = [argv0 as *mut c_char, ptr::null_mut()];
+	let mut argc = (argv.len() - 1) as c_int;
+	unsafe {
+		hs_init(&mut argc, &mut argv.as_mut_ptr());
+	}
+}
+
+/// Stop the haskell runtime
+///
+/// This should only be called after the `hs_start()` function has been invoked
+
+pub fn hs_stop() {
+	unsafe{hs_exit()};
+}

--- a/src/hsrt.rs
+++ b/src/hsrt.rs
@@ -18,7 +18,7 @@ extern {
 /// do so will cause undefined behavior and the runtime will run without
 /// stopping. This could cause memory leaks or a whole bunch of other
 /// errors that can't be checked.
-pub fn hs_start(mut func: String) {
+pub fn start(mut func: String) {
 	func.push('\0');
 	let argv0 = func.as_ptr();
 	let mut argv = [argv0 as *mut c_char, ptr::null_mut()];
@@ -32,6 +32,6 @@ pub fn hs_start(mut func: String) {
 ///
 /// This should only be called after the `hs_start()` function has been invoked
 
-pub fn hs_stop() {
+pub fn stop() {
 	unsafe{hs_exit()};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@
 pub mod macros;
 pub mod convert;
 pub mod types;
+pub mod hsrt;

--- a/tests/haskell_import.rs
+++ b/tests/haskell_import.rs
@@ -1,31 +1,18 @@
 extern crate curryrs;
 use curryrs::types::*;
-use std::os::raw::c_int;
-use std::ptr;
+use curryrs::hsrt::*;
 
 #[link(name = "htest", kind = "dylib")]
 extern {
 	pub fn triple(x: I32) -> I32;
 }
 
-include!(concat!(env!("OUT_DIR"), "/hs_rts.rs"));
-
-extern {
-	pub fn hs_init(argc: *mut c_int, argv: *mut *mut *mut c_char);
-	pub fn hs_exit();
-}
 
 fn triple_num(x: I32) -> I32 {
-	let mut argv0 = *b"triple_test\0";
-	let mut argv = [argv0.as_mut_ptr() as *mut c_char, ptr::null_mut()];
-	let mut argc = (argv.len() - 1) as c_int;
-
-	unsafe {
-		hs_init(&mut argc, &mut argv.as_mut_ptr());
-		let y = triple(x);
-		hs_exit();
+		hs_start("triple".to_string());
+		let y = unsafe{triple(x)};
+		hs_stop();
 		y
-	}
 }
 
 #[test]

--- a/tests/haskell_import.rs
+++ b/tests/haskell_import.rs
@@ -1,6 +1,6 @@
 extern crate curryrs;
 use curryrs::types::*;
-use curryrs::hsrt::*;
+use curryrs::hsrt;
 
 #[link(name = "htest", kind = "dylib")]
 extern {
@@ -9,9 +9,9 @@ extern {
 
 
 fn triple_num(x: I32) -> I32 {
-		hs_start("triple".to_string());
+		hsrt::start("triple".to_string());
 		let y = unsafe{triple(x)};
-		hs_stop();
+		hsrt::stop();
 		y
 }
 


### PR DESCRIPTION
This commit does quite a number of things but the important part is that
it adds two functions that allow one to start and stop the Haskell
Runtime from one's code without needing to deal with all of the library
linking. The build script now goes to the ghc library directory where the
code is located and finds all of the .so files and links against them
to avoid dependency issues and making it easier to deal with other
Haskell code in the future. This means the user doesn't need to worry
about linking when it comes to getting the right Haskell libraries
involved beyond their own library they've created. They also just need
to use the library to start and stop the runtime without worrying about
getting the right C code types lined up just right.