### PR TITLE
Haskell type parser using combine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace]
-members = ["rtest", "hrgen"]
+members = ["rtest", "hrgen", "hrgen/hs-type-parser"]
 
 [dependencies]
 

--- a/hrgen/Cargo.toml
+++ b/hrgen/Cargo.toml
@@ -12,3 +12,4 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 clap = "^2.13"
+hs-type-parser = { version = "0.1", path = "hs-type-parser" }

--- a/hrgen/hs-type-parser/Cargo.toml
+++ b/hrgen/hs-type-parser/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hs-type-parser"
+version = "0.1.0"
+authors = ["NanoTech <nanotech@nanotechcorp.net>"]
+license = "MIT/Apache-2.0"
+
+[dependencies]
+combine = "2.0"
+combine-language = "2.0"

--- a/hrgen/hs-type-parser/src/lib.rs
+++ b/hrgen/hs-type-parser/src/lib.rs
@@ -146,3 +146,23 @@ fn lex<P: Parser<Input=I>, I>(p: P) -> Seq<Right, Whitespace<I>, P>
 {
 	seqr(whitespace(), p)
 }
+
+#[test]
+fn parse_type_test() {
+	assert_eq!(parse_type("Int"), Ok(((constr("Int")), "")));
+	assert_eq!(parse_type("a"), Ok(((var("a")), "")));
+	assert_eq!(parse_type("(a)"), Ok(((var("a")), "")));
+	assert_eq!(parse_type("Vec a"), Ok((app(constr("Vec"), var("a")), "")));
+	assert_eq!(parse_type("f   a"), Ok((app(var("f"), var("a")), "")));
+	assert_eq!(parse_type("In a -> Out"),
+	         Ok((func(app(constr("In"), var("a")), constr("Out")), "")));
+	assert_eq!(parse_type("In a -> (In b -> Out) -> Out"),
+	         Ok((func(app(constr("In"), var("a")),
+	               func(func(app(constr("In"), var("b")), constr("Out")), constr("Out"))),
+	            "")));
+	assert_eq!(parse_type("FunPtr (I32 -> IO I32) -> IO ()"),
+	           Ok((func(app(constr("FunPtr"),
+	                        func(constr("I32"), app(constr("IO"), constr("I32")))),
+	                    app(constr("IO"), constr("()"))),
+	               "")));
+}

--- a/hrgen/hs-type-parser/src/lib.rs
+++ b/hrgen/hs-type-parser/src/lib.rs
@@ -1,0 +1,148 @@
+extern crate combine;
+extern crate combine_language;
+use combine::Parser;
+use std::borrow::Cow;
+use std::marker::PhantomData;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Type {
+	Constr(Cow<'static, str>),
+	Var(String),
+	App(Box<Type>, Box<Type>),
+}
+
+pub fn constr<S: Into<Cow<'static, str>>>(name: S) -> Type {
+	Type::Constr(name.into())
+}
+
+pub fn var<S: Into<String>>(name: S) -> Type {
+	Type::Var(name.into())
+}
+
+pub fn app(l: Type, r: Type) -> Type {
+	Type::App(Box::new(l), Box::new(r))
+}
+
+pub fn app2(x: Type, y: Type, z: Type) -> Type {
+	app(app(x, y), z)
+}
+
+pub fn func(l: Type, r: Type) -> Type {
+	app2(constr("->"), l, r)
+}
+
+#[derive(Clone, Copy)]
+struct TypeParser<I>(PhantomData<I>);
+
+impl<I> Parser for TypeParser<I>
+	where I: combine::Stream<Item = char>
+{
+	type Input = I;
+	type Output = Type;
+	fn parse_lazy(&mut self, input: I) -> combine::ConsumedResult<Type, I> {
+		use combine::*;
+		use combine::char::*;
+		use combine_language::*;
+
+		fn char_join(cs: (char, String)) -> String {
+			let (c, mut s) = cs;
+			s.insert(0, c);
+			s
+		}
+
+		fn is_ident_tail(c: char) -> bool {
+			c.is_alphanumeric() || c == '\'' || c == '#'
+		}
+
+		let var_parser = try(lex((lower(), many(satisfy(is_ident_tail))))
+			.map(char_join).map(var));
+		let constr_parser = try(lex((upper(), many(satisfy(is_ident_tail))))
+			.map(char_join).map(constr));
+		let arrow = try(lex(string("->"))).map(|s| constr(s));
+		let unit = try(lex(string("()"))).map(constr);
+		let paren = try(lex((char('('), type_parser(), char(')')))).map(|t| t.1);
+
+		let term = unit.or(paren).or(constr_parser).or(var_parser);
+
+		let op_parser = arrow.map(Some).or(skip_many1(space()).map(|_| None)).map(|op| {
+			match op {
+				Some(_) => (op, Assoc { precedence: 1, fixity: Fixity::Right }),
+				None => (op, Assoc { precedence: 2, fixity: Fixity::Left }),
+			}
+		});
+		let mut expr = expression_parser(term, op_parser, |l, o, r| {
+			match o {
+				Some(op) => app2(op, l, r),
+				None => app(l, r),
+			}
+		});
+		expr.parse_lazy(input)
+	}
+}
+
+fn type_parser<I: combine::Stream<Item = char>>() -> TypeParser<I> {
+	TypeParser(PhantomData)
+}
+
+pub fn parse_type(input: &str) -> Result<(Type, &str), combine::ParseError<&str>> {
+	type_parser().parse(input)
+}
+
+// Parsing support
+
+#[derive(Clone, Copy)]
+struct Whitespace<I>(PhantomData<I>);
+
+impl<I> Parser for Whitespace<I>
+	where I: combine::Stream<Item = char>
+{
+	type Input = I;
+	type Output = ();
+	fn parse_lazy(&mut self, input: I) -> combine::ConsumedResult<(), I> {
+		combine::char::spaces().map(|_| ()).parse_lazy(input)
+	}
+}
+
+fn whitespace<I: combine::Stream<Item = char>>() -> Whitespace<I> {
+	Whitespace(PhantomData)
+}
+
+enum Right {}
+
+trait Selector<Input> {
+	type Output;
+	fn select(t: Input) -> Self::Output;
+}
+
+impl<L, R> Selector<(L, R)> for Right {
+	type Output = R;
+	fn select(t: (L, R)) -> Self::Output { t.1 }
+}
+
+/// Sequence two parsers. Keep the selected result and discard the other.
+#[derive(Clone, Copy)]
+struct Seq<S, L, R>(L, R, PhantomData<S>);
+
+impl<S, L, R> Parser for Seq<S, L, R>
+	where L: Parser<Input=R::Input>,
+			R: Parser,
+			S: Selector<(L::Output, R::Output)>
+{
+	type Input = R::Input;
+	type Output = S::Output;
+	fn parse_lazy(&mut self, input: Self::Input) -> combine::ConsumedResult<Self::Output, Self::Input> {
+		(&mut self.0, &mut self.1).parse_lazy(input).map(|t| S::select(t))
+	}
+}
+
+fn seqr<L, R>(l: L, r: R) -> Seq<Right, L, R>
+	where L: Parser<Input=R::Input>, R: Parser
+{
+	Seq(l, r, PhantomData::<Right>)
+}
+
+fn lex<P: Parser<Input=I>, I>(p: P) -> Seq<Right, Whitespace<I>, P>
+	where I: combine::Stream<Item = char>
+{
+	seqr(whitespace(), p)
+}

--- a/hrgen/src/main.rs
+++ b/hrgen/src/main.rs
@@ -1,4 +1,5 @@
 extern crate clap;
+extern crate hs_type_parser;
 use clap::{Arg, App};
 use std::io::prelude::*;
 use std::fs::File;
@@ -55,6 +56,28 @@ fn main() {
 
 	output_buffer.push('}');
 	println!("{}",output_buffer);
+}
+
+#[test]
+fn parse_hs_type_test() {
+	use hs_type_parser::*;
+
+	assert_eq!(parse_type("Int"), Ok(((constr("Int")), "")));
+	assert_eq!(parse_type("a"), Ok(((var("a")), "")));
+	assert_eq!(parse_type("(a)"), Ok(((var("a")), "")));
+	assert_eq!(parse_type("Vec a"), Ok((app(constr("Vec"), var("a")), "")));
+	assert_eq!(parse_type("f   a"), Ok((app(var("f"), var("a")), "")));
+	assert_eq!(parse_type("In a -> Out"),
+	         Ok((func(app(constr("In"), var("a")), constr("Out")), "")));
+	assert_eq!(parse_type("In a -> (In b -> Out) -> Out"),
+	         Ok((func(app(constr("In"), var("a")),
+	               func(func(app(constr("In"), var("b")), constr("Out")), constr("Out"))),
+	            "")));
+	assert_eq!(parse_type("FunPtr (I32 -> IO I32) -> IO ()"),
+	           Ok((func(app(constr("FunPtr"),
+	                        func(constr("I32"), app(constr("IO"), constr("I32")))),
+	                    app(constr("IO"), constr("()"))),
+	               "")));
 }
 
 fn parse_hs_export(buffer: &mut String, line: String) {

--- a/hrgen/src/main.rs
+++ b/hrgen/src/main.rs
@@ -58,28 +58,6 @@ fn main() {
 	println!("{}",output_buffer);
 }
 
-#[test]
-fn parse_hs_type_test() {
-	use hs_type_parser::*;
-
-	assert_eq!(parse_type("Int"), Ok(((constr("Int")), "")));
-	assert_eq!(parse_type("a"), Ok(((var("a")), "")));
-	assert_eq!(parse_type("(a)"), Ok(((var("a")), "")));
-	assert_eq!(parse_type("Vec a"), Ok((app(constr("Vec"), var("a")), "")));
-	assert_eq!(parse_type("f   a"), Ok((app(var("f"), var("a")), "")));
-	assert_eq!(parse_type("In a -> Out"),
-	         Ok((func(app(constr("In"), var("a")), constr("Out")), "")));
-	assert_eq!(parse_type("In a -> (In b -> Out) -> Out"),
-	         Ok((func(app(constr("In"), var("a")),
-	               func(func(app(constr("In"), var("b")), constr("Out")), constr("Out"))),
-	            "")));
-	assert_eq!(parse_type("FunPtr (I32 -> IO I32) -> IO ()"),
-	           Ok((func(app(constr("FunPtr"),
-	                        func(constr("I32"), app(constr("IO"), constr("I32")))),
-	                    app(constr("IO"), constr("()"))),
-	               "")));
-}
-
 fn parse_hs_export(buffer: &mut String, line: String) {
 	// List that we draw from for function headers
 	let symbols = ['a','b','c','d','e','f','g','h','i','j','k','l','m',


### PR DESCRIPTION
It should be able to parse any Haskell 2010 type except for type class constraints and type operators. This isn't connected to the generator yet, and doesn't parse the `foreign export ccall` part yet. The parser is in a separate crate since it's a bit slow to compile.