### PR TITLE
Safer and more convenient Haskell runtime start and stop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ exclude = [
 members = ["rtest", "hrgen", "hrgen/hs-type-parser"]
 
 [dependencies]
+libc = "0.2"
 
 [features]
 # Features available for choosing alternative

--- a/htest/src/Lib.hs
+++ b/htest/src/Lib.hs
@@ -2,9 +2,17 @@
 
 module Lib where
 
+import System.Environment (getProgName)
+import Foreign.C.String (newCString)
+
 import Curryrs.Types
 
 triple :: I64 -> I64
 triple x = 3 * x
 
 foreign export ccall triple :: I64 -> I64
+
+getProgNameStr :: IO Str
+getProgNameStr = getProgName >>= newCString
+
+foreign export ccall getProgNameStr :: IO Str

--- a/src/hsrt.rs
+++ b/src/hsrt.rs
@@ -12,17 +12,44 @@ extern {
 
 /// Initialize the Haskell runtime
 ///
-/// func is what you pass to the argv part of the C Call to hs_init
-///
 /// If you call `hs_start()` you absolutely must call `hs_stop()` forgetting to
 /// do so will cause undefined behavior and the runtime will run without
 /// stopping. This could cause memory leaks or a whole bunch of other
 /// errors that can't be checked.
-pub fn start(mut func: String) {
-	func.push('\0');
-	let argv0 = func.as_ptr();
-	let mut argv = [argv0 as *mut c_char, ptr::null_mut()];
-	let mut argc = (argv.len() - 1) as c_int;
+pub fn start() {
+	start_impl();
+}
+
+#[cfg(not(windows))]
+fn start_impl() {
+	// OsString is expected to contain either byte-sized characters or UTF-8
+	// on every platform except Windows.
+	//
+	// It's safe to unwrap the CString here as program arguments can't
+	// contain nul bytes.
+	use std::ffi::CString;
+	use std::os::unix::ffi::OsStrExt;
+	let mut args: Vec<_> = ::std::env::args_os()
+		.map(|s| CString::new(s.as_os_str().as_bytes()).unwrap().into_bytes_with_nul())
+		.collect();
+	let mut argv = Vec::with_capacity(args.len() + 1);
+	for ref mut arg in &mut args {
+		argv.push(arg.as_mut_ptr() as *mut c_char);
+	}
+	argv.push(ptr::null_mut());
+	let mut argc = args.len() as c_int;
+	unsafe {
+		hs_init(&mut argc, &mut argv.as_mut_ptr());
+	}
+}
+
+#[cfg(windows)]
+fn start_impl() {
+	// GHC on Windows ignores hs_init arguments and uses GetCommandLineW instead.
+	// See https://hackage.haskell.org/package/base-4.9.0.0/docs/src/GHC.Environment.html
+	let mut argv0 = *b"\0";
+	let mut argv = [argv0.as_mut_ptr() as *mut c_char, ptr::null_mut()];
+	let mut argc = 1;
 	unsafe {
 		hs_init(&mut argc, &mut argv.as_mut_ptr());
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
         trivial_casts, trivial_numeric_casts, unused_import_braces, unused_qualifications)]
 //! Curryrs is a library made for bridging the gap between Rust and Haskell making it easy
 //! to use code in from either language in the other.
+extern crate libc;
 pub mod macros;
 pub mod convert;
 pub mod types;

--- a/tests/haskell_import.rs
+++ b/tests/haskell_import.rs
@@ -13,14 +13,20 @@ extern {
 	pub fn getProgNameStr() -> Str;
 }
 
+fn triple_num(x: I32) -> I32 {
+	hsrt::start();
+	unsafe { triple(x) }
+}
+
 #[test]
 fn ffi_test() {
+	// TODO Use the threaded Haskell runtime to let tests run safely in
+	//      parallel, allowing separate test functions.
+
+	assert_eq!(900, triple_num(300));
+
 	hsrt::start();
-	// TODO Split these tests up
-	let y = unsafe { triple(300) };
 	let prog_name = unsafe { getProgNameStr() };
-	hsrt::stop();
-	assert_eq!(900, y);
 	assert!(!prog_name.is_null());
 	let prog_name_str = unsafe { CStr::from_ptr(prog_name) }.to_str().unwrap();
 	let argv0 = env::args().nth(0).unwrap();

--- a/tests/haskell_import.rs
+++ b/tests/haskell_import.rs
@@ -1,21 +1,29 @@
 extern crate curryrs;
+
+use std::env;
+use std::ffi::CStr;
+use std::path::Path;
+
 use curryrs::types::*;
 use curryrs::hsrt;
 
 #[link(name = "htest", kind = "dylib")]
 extern {
 	pub fn triple(x: I32) -> I32;
-}
-
-
-fn triple_num(x: I32) -> I32 {
-		hsrt::start("triple".to_string());
-		let y = unsafe{triple(x)};
-		hsrt::stop();
-		y
+	pub fn getProgNameStr() -> Str;
 }
 
 #[test]
-fn triple_test() {
-	assert_eq!(900, triple_num(300));
+fn ffi_test() {
+	hsrt::start();
+	// TODO Split these tests up
+	let y = unsafe { triple(300) };
+	let prog_name = unsafe { getProgNameStr() };
+	hsrt::stop();
+	assert_eq!(900, y);
+	assert!(!prog_name.is_null());
+	let prog_name_str = unsafe { CStr::from_ptr(prog_name) }.to_str().unwrap();
+	let argv0 = env::args().nth(0).unwrap();
+	let argv0_file_name = Path::new(&argv0).file_name().unwrap();
+	assert_eq!(prog_name_str, argv0_file_name.to_str().unwrap());
 }


### PR DESCRIPTION
- Let `hsrt::start` be called any number of times, ignoring subsequent calls.
- Automatically call `hs_exit` at program exit.
- Panic as a diagnostic if `hsrt::stop` is called manually more than once.

`hsrt::stop` doesn't technically need to panic, it could just ignore subsequent calls like `hsrt::start`, but I think that if you are going to call it manually, you should know exactly when all your exported Haskell functions become erroneous to call.

The tests are still in one `#[test]` function as Rust's test runner runs them in parallel and `htest` doesn't use the threaded runtime. It would be nice if we could set the `threaded` feature for `profile.test`, although I don't think that's currently possible with Cargo.

The Windows implementation for argument passing is correct as far as I can tell from the GHC sources, but not actually tested on Windows.

Provides a piece of #14.
